### PR TITLE
Only ack events if any have been emitted

### DIFF
--- a/src/Event/Command/ScxApiEventConsumeCommand.php
+++ b/src/Event/Command/ScxApiEventConsumeCommand.php
@@ -58,7 +58,12 @@ class ScxApiEventConsumeCommand extends AbstractCommand
             }
 
             $emittedEventIdList = $this->eventEnqueuer->emit($response->getEventList());
-            $this->logger->info(count($emittedEventIdList) . " events emitted.");
+            $emittedEventCount = count($emittedEventIdList);
+            $this->logger->info($emittedEventCount . " events emitted.");
+
+            if ($emittedEventCount === 0) {
+                return;
+            }
 
             $this->eventApi->ack(new AcknowledgeEventIdListRequest($emittedEventIdList));
             $this->logger->info("Events successful acknowledged");


### PR DESCRIPTION
Events should only be acked if there is at least one successfully emitted event by the RabbitMQ emitter. Otherwise the SCX API will return an error.