### PR TITLE
EA-7386: Include vhost in RabbitMqQueueLister URL and add test coverage

### DIFF
--- a/src/Core/RabbitMqManagementApi/RabbitMqQueueLister.php
+++ b/src/Core/RabbitMqManagementApi/RabbitMqQueueLister.php
@@ -43,7 +43,8 @@ class RabbitMqQueueLister implements AmqpQueueLister
             $url = substr($url, 0, -1);
         }
 
-        $url .= ":{$con->getHttpPort()}/api/queues";
+        $vhost = rawurlencode($con->getVhost());
+        $url .= ":{$con->getHttpPort()}/api/queues/{$vhost}";
         $response = $this->client->request(
             'GET',
             $url,

--- a/tests/Core/RabbitMqManagementApi/RabbitMqQueueListerTest.php
+++ b/tests/Core/RabbitMqManagementApi/RabbitMqQueueListerTest.php
@@ -49,6 +49,7 @@ class RabbitMqQueueListerTest extends TestCase
         $port = (string)random_int(1025, 100000);
         $username = uniqid('username', true);
         $password = uniqid('password', true);
+        $vhost = 'kaufland';
         $responseString = '[{"name": "queue1"}, {"name": "queue2"}]';
 
         $response = $this->createMock(Response::class);
@@ -67,6 +68,10 @@ class RabbitMqQueueListerTest extends TestCase
             ->willReturn($port);
 
         $this->connectionSettings->expects(self::once())
+            ->method('getVhost')
+            ->willReturn($vhost);
+
+        $this->connectionSettings->expects(self::once())
             ->method('getUser')
             ->willReturn($username);
 
@@ -78,7 +83,7 @@ class RabbitMqQueueListerTest extends TestCase
             ->method('request')
             ->with(
                 'GET',
-                "{$host}:{$port}/api/queues",
+                "{$host}:{$port}/api/queues/{$vhost}",
                 ['auth' => [$username, $password]]
             )
             ->willReturn($response);
@@ -102,12 +107,52 @@ class RabbitMqQueueListerTest extends TestCase
     /**
      * @test
      */
+    public function vhostIsUrlEncodedInQueueListUrl(): void
+    {
+        $host = uniqid('host', true);
+        $port = (string)random_int(1025, 100000);
+        $vhost = '/';
+        $responseString = '[{"name": "queue1"}]';
+
+        $response = $this->createMock(Response::class);
+        $responseBody = $this->createMock(StreamInterface::class);
+
+        $this->transport->expects(self::once())
+            ->method('getConnectionSettings')
+            ->willReturn($this->connectionSettings);
+
+        $this->connectionSettings->method('getHost')->willReturn($host);
+        $this->connectionSettings->method('getHttpPort')->willReturn($port);
+        $this->connectionSettings->method('getVhost')->willReturn($vhost);
+        $this->connectionSettings->method('getUser')->willReturn('user');
+        $this->connectionSettings->method('getPassword')->willReturn('pass');
+
+        $this->client->expects(self::once())
+            ->method('request')
+            ->with(
+                'GET',
+                "{$host}:{$port}/api/queues/%2F",
+                ['auth' => ['user', 'pass']]
+            )
+            ->willReturn($response);
+
+        $response->method('getStatusCode')->willReturn(200);
+        $response->method('getBody')->willReturn($responseBody);
+        $responseBody->method('getContents')->willReturn($responseString);
+
+        $this->lister->listQueues();
+    }
+
+    /**
+     * @test
+     */
     public function failListQueuesIfStatusCodeIsNot200(): void
     {
         $host = uniqid('host', true);
         $port = (string)random_int(1025, 100000);
         $username = uniqid('username', true);
         $password = uniqid('password', true);
+        $vhost = 'kaufland';
 
         $response = $this->createMock(Response::class);
 
@@ -124,6 +169,10 @@ class RabbitMqQueueListerTest extends TestCase
             ->willReturn($port);
 
         $this->connectionSettings->expects(self::once())
+            ->method('getVhost')
+            ->willReturn($vhost);
+
+        $this->connectionSettings->expects(self::once())
             ->method('getUser')
             ->willReturn($username);
 
@@ -135,7 +184,7 @@ class RabbitMqQueueListerTest extends TestCase
             ->method('request')
             ->with(
                 'GET',
-                "{$host}:{$port}/api/queues",
+                "{$host}:{$port}/api/queues/{$vhost}",
                 ['auth' => [$username, $password]]
             )
             ->willReturn($response);


### PR DESCRIPTION
Problem

  When running queue:dead-letter.retry, queues from other channels (Otto, Mirakl, etc.) were being created inside the wrong channel's vhost (e.g. Kaufland). This happened because RabbitMqQueueLister::listQueues() called /api/queues on the RabbitMQ Management API without scoping it to a vhost, returning dead-letter
  queues from every vhost the management user can see.

  DeadLetterRetryCommand then called AmqpTransport::countMessagesInQueue() for each returned queue name. Since countMessagesInQueue uses queue_declare with passive=false, it silently created any queue that didn't already exist — stamping all foreign queues into the current channel's vhost.

  Fix

  Scope the Management API call to the channel's own vhost:

  // Before
  $url .= ":{$con->getHttpPort()}/api/queues";

  // After
  $vhost = rawurlencode($con->getVhost());
  $url .= ":{$con->getHttpPort()}/api/queues/{$vhost}";

  rawurlencode is required because the default vhost / must be transmitted as %2F.

  Changes

  - src/Core/RabbitMqManagementApi/RabbitMqQueueLister.php — append /{vhost} to the queue listing URL
  - tests/Core/RabbitMqManagementApi/RabbitMqQueueListerTest.php — assert getVhost() is called and the vhost appears in the URL; add a dedicated test for / vhost URL-encoding

  Testing

  - Existing tests updated to assert vhost is included in the request URL
  - New test vhostIsUrlEncodedInQueueListUrl verifies the default / vhost is correctly encoded as %2F
 