### PR TITLE
EA-6902: ✨ feat(channel-api): allow errorLongMessage on SendOfferListingFailedMessage

### DIFF
--- a/src/ChannelApi/SendOfferListingFailedMessage.php
+++ b/src/ChannelApi/SendOfferListingFailedMessage.php
@@ -31,6 +31,7 @@ class SendOfferListingFailedMessage extends AbstractAmqpTransportableMessage imp
         string|null $messageId = null,
         string|null $relatedAttributeId = null,
         string|null $recommendedValue = null,
+        string|null $errorLongMessage = null,
     ) {
         parent::__construct($messageId);
 
@@ -38,6 +39,7 @@ class SendOfferListingFailedMessage extends AbstractAmqpTransportableMessage imp
         $this->addError(
             errorCode: $errorCode,
             errorMessage: $errorMessage,
+            errorLongMessage: $errorLongMessage,
             relatedAttributeId: $relatedAttributeId,
             recommendedValue: $recommendedValue
         );

--- a/tests/ChannelApi/SendOfferListingFailedMessageTest.php
+++ b/tests/ChannelApi/SendOfferListingFailedMessageTest.php
@@ -211,5 +211,99 @@ TXT;
         self::assertEquals($recommendedValue, $err[1]->getRecommendedValue());
     }
 
+    /**
+     * @test
+     * @ticket EA-6902
+     */
+    public function it_can_add_errorLongMessage_in_constructor(): void
+    {
+        $errorLongMessage = uniqid('errorLongMessage', true);
+        $sut = new SendOfferListingFailedMessage(
+            $this->createStub(ChannelSellerId::class),
+            123,
+            'ERR_111',
+            'smallError',
+            errorLongMessage: $errorLongMessage
+        );
 
+        $err = $sut->getErrorList();
+
+        self::assertArrayHasKey(0, $err);
+        self::assertSame('smallError', $err[0]->getMessage());
+        self::assertSame($errorLongMessage, $err[0]->getLongMessage());
+    }
+
+    /**
+     * @test
+     * @ticket EA-6902
+     */
+    public function it_keeps_longMessage_null_when_errorLongMessage_is_not_given(): void
+    {
+        $sut = new SendOfferListingFailedMessage(
+            $this->createStub(ChannelSellerId::class),
+            123,
+            'ERR_111',
+            'smallError',
+        );
+
+        $err = $sut->getErrorList();
+
+        self::assertArrayHasKey(0, $err);
+        self::assertNull($err[0]->getLongMessage());
+    }
+
+    /**
+     * @test
+     * @ticket EA-6902
+     */
+    public function it_keeps_both_texts_when_errorLongMessage_meets_an_oversized_errorMessage(): void
+    {
+        $errorMessage = str_repeat('A', 251);
+        $errorLongMessage = str_repeat('B', 251);
+
+        $sut = new SendOfferListingFailedMessage(
+            $this->createStub(ChannelSellerId::class),
+            123,
+            'ERR_111',
+            $errorMessage,
+            errorLongMessage: $errorLongMessage
+        );
+
+        $err = $sut->getErrorList();
+
+        self::assertArrayHasKey(0, $err);
+        self::assertSame(250, mb_strlen($err[0]->getMessage()));
+        self::assertSame("{$errorLongMessage}\n{$errorMessage}", $err[0]->getLongMessage());
+    }
+
+    /**
+     * The new parameter must be appended at the very end of the signature. Every earlier position
+     * would shift $failedAt/$messageId/$relatedAttributeId/$recommendedValue and break positional
+     * callers like this one. See EA-6902.
+     *
+     * @test
+     * @ticket EA-6902
+     */
+    public function it_stays_backwards_compatible_for_positional_callers(): void
+    {
+        $sellerId = $this->createStub(ChannelSellerId::class);
+        $failedAt = $this->createStub(\DateTime::class);
+
+        $sut = new SendOfferListingFailedMessage(
+            $sellerId,
+            123,
+            'ERR_111',
+            'smallError',
+            $failedAt,
+            'MSG_ID',
+            'related attribute',
+            'some recommended value'
+        );
+
+        self::assertSame($failedAt, $sut->getFailedAt());
+        self::assertSame('MSG_ID', $sut->getMessageId());
+        self::assertSame('related attribute', $sut->getErrorList()[0]->getRelatedAttributeId());
+        self::assertSame('some recommended value', $sut->getErrorList()[0]->getRecommendedValue());
+        self::assertNull($sut->getErrorList()[0]->getLongMessage());
+    }
 }


### PR DESCRIPTION
## Problem

`addError()` has always accepted an `errorLongMessage`, but the **constructor never passed one through**, and `errorList` is private with only a getter. There was therefore no supported way to set a `longMessage` on the error the constructor creates:

- a second `addError()` call appends a *second* error instead of enriching the first
- `GenericCollection` has no `clear()`, and `offsetUnset(0) + add()` lands on key `1` because PHP does not reset the next integer key
- `ListingFailedError` has only private properties with getters

## Why it is needed

This blocks [EA-6902](https://github.com/jtl-software/jtl-marketplaces-scx-mirakl/pull/36) in channel-mirakl. A rejected offer listing must carry a **German** merchant-facing `message`, while the quoted — usually English — marketplace text goes to `longMessage`. Without this parameter the only alternatives were reaching into `getErrorList()->offsetSet(0, …)` (touching a message's internals) or dropping the marketplace detail entirely.

## The change

Two production lines: one optional constructor parameter, passed through to `addError()`.

The parameter is appended at the **very end** of the signature. Any earlier position would shift `failedAt` / `messageId` / `relatedAttributeId` / `recommendedValue` and break every positional caller — `it_stays_backwards_compatible_for_positional_callers` pins exactly that.

## Tests

Four new cases: `longMessage` is set when given; default `null` behaves exactly as before (regression guard); an explicitly passed `longMessage` plus an oversized `errorMessage` keeps **both** texts (the 250-character logic appends rather than overwrites); and positional backwards compatibility.

Suite: 1322 tests / 5329 assertions. The 3 errors in `SalesChannelBaseTest` are pre-existing (missing generated classes `ChannelFeatureList`, `MinimumClientsVersionRequired`, `MarketplaceChannelList`) and unrelated. PHPStan `[OK] No errors`.

## Release

Please release as **2.4.0** so channel-mirakl can move its constraint from `^2.2` to `^2.4`. Until then the EA-6902 branch there is not deployable.

The same gap exists on `master` (3.x) and is prepared as a separate PR — without it, upgrading channel-mirakl to 3.x would silently lose the capability again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
