### PR TITLE
EA-6902: ✨ feat(channel-api): allow errorLongMessage on SendOfferListingFailedMessage (3.x forward-port)

### DIFF
--- a/src/ChannelApi/SendOfferListingFailedMessage.php
+++ b/src/ChannelApi/SendOfferListingFailedMessage.php
@@ -31,6 +31,7 @@ class SendOfferListingFailedMessage extends AbstractAmqpTransportableMessage imp
         string|null $messageId = null,
         string|null $relatedAttributeId = null,
         string|null $recommendedValue = null,
+        string|null $errorLongMessage = null,
     ) {
         parent::__construct($messageId);
 
@@ -38,6 +39,7 @@ class SendOfferListingFailedMessage extends AbstractAmqpTransportableMessage imp
         $this->addError(
             errorCode: $errorCode,
             errorMessage: $errorMessage,
+            errorLongMessage: $errorLongMessage,
             relatedAttributeId: $relatedAttributeId,
             recommendedValue: $recommendedValue
         );

--- a/tests/ChannelApi/SendOfferListingFailedMessageTest.php
+++ b/tests/ChannelApi/SendOfferListingFailedMessageTest.php
@@ -211,5 +211,99 @@ TXT;
         self::assertEquals($recommendedValue, $err[1]->getRecommendedValue());
     }
 
+    /**
+     * @test
+     * @ticket EA-6902
+     */
+    public function it_can_add_errorLongMessage_in_constructor(): void
+    {
+        $errorLongMessage = uniqid('errorLongMessage', true);
+        $sut = new SendOfferListingFailedMessage(
+            $this->createStub(ChannelSellerId::class),
+            123,
+            'ERR_111',
+            'smallError',
+            errorLongMessage: $errorLongMessage
+        );
 
+        $err = $sut->getErrorList();
+
+        self::assertArrayHasKey(0, $err);
+        self::assertSame('smallError', $err[0]->getMessage());
+        self::assertSame($errorLongMessage, $err[0]->getLongMessage());
+    }
+
+    /**
+     * @test
+     * @ticket EA-6902
+     */
+    public function it_keeps_longMessage_null_when_errorLongMessage_is_not_given(): void
+    {
+        $sut = new SendOfferListingFailedMessage(
+            $this->createStub(ChannelSellerId::class),
+            123,
+            'ERR_111',
+            'smallError',
+        );
+
+        $err = $sut->getErrorList();
+
+        self::assertArrayHasKey(0, $err);
+        self::assertNull($err[0]->getLongMessage());
+    }
+
+    /**
+     * @test
+     * @ticket EA-6902
+     */
+    public function it_keeps_both_texts_when_errorLongMessage_meets_an_oversized_errorMessage(): void
+    {
+        $errorMessage = str_repeat('A', 251);
+        $errorLongMessage = str_repeat('B', 251);
+
+        $sut = new SendOfferListingFailedMessage(
+            $this->createStub(ChannelSellerId::class),
+            123,
+            'ERR_111',
+            $errorMessage,
+            errorLongMessage: $errorLongMessage
+        );
+
+        $err = $sut->getErrorList();
+
+        self::assertArrayHasKey(0, $err);
+        self::assertSame(250, mb_strlen($err[0]->getMessage()));
+        self::assertSame("{$errorLongMessage}\n{$errorMessage}", $err[0]->getLongMessage());
+    }
+
+    /**
+     * The new parameter must be appended at the very end of the signature. Every earlier position
+     * would shift $failedAt/$messageId/$relatedAttributeId/$recommendedValue and break positional
+     * callers like this one. See EA-6902.
+     *
+     * @test
+     * @ticket EA-6902
+     */
+    public function it_stays_backwards_compatible_for_positional_callers(): void
+    {
+        $sellerId = $this->createStub(ChannelSellerId::class);
+        $failedAt = $this->createStub(\DateTime::class);
+
+        $sut = new SendOfferListingFailedMessage(
+            $sellerId,
+            123,
+            'ERR_111',
+            'smallError',
+            $failedAt,
+            'MSG_ID',
+            'related attribute',
+            'some recommended value'
+        );
+
+        self::assertSame($failedAt, $sut->getFailedAt());
+        self::assertSame('MSG_ID', $sut->getMessageId());
+        self::assertSame('related attribute', $sut->getErrorList()[0]->getRelatedAttributeId());
+        self::assertSame('some recommended value', $sut->getErrorList()[0]->getRecommendedValue());
+        self::assertNull($sut->getErrorList()[0]->getLongMessage());
+    }
 }


### PR DESCRIPTION
## What this is

Forward-port of jtl-scx/channel-core#380 (the 2.x fix, to be released as 2.4.0) onto `master` / 3.x.

**Reason it is a separate PR:** channel-mirakl currently requires `^2.2`, so the fix has to land on the 2.x maintenance line to be usable. Without this forward-port, upgrading channel-mirakl from 2.x to 3.x later would silently lose the capability again — a regression trap.

## Problem (same as #380)

`addError()` has always accepted an `errorLongMessage`, but the constructor never passed one through, and `errorList` is private with only a getter. There was therefore no supported way to set a `longMessage` on the error the constructor creates: a second `addError()` call appends a second error instead of enriching the first, and `GenericCollection` has no `clear()`.

[EA-6902](https://github.com/jtl-software/jtl-marketplaces-scx-mirakl/pull/36) in channel-mirakl needs it so a rejected offer listing can carry a German merchant-facing `message` while the quoted, usually English marketplace text goes to `longMessage`.

## The change

Identical to #380: two production lines, one optional constructor parameter passed through to `addError()`, appended at the **very end** of the signature so no positional caller breaks. `it_stays_backwards_compatible_for_positional_callers` pins that.

## Note for the reviewer

Rebased onto current `master`; the diff is exactly the 2 files. The test suite for this branch was **not** executed locally — the local dev container is bound to the 2.x working copy, so verification here relies on CI. The change is identical to #380, where the suite ran green (1322 tests / 5329 assertions, 3 pre-existing `SalesChannelBaseTest` errors, PHPStan `[OK]`).

Merge order does not matter functionally, but #380 is the one that unblocks channel-mirakl.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
