### PR TITLE
fix(serializer): preserve bool/int/float through sanitizeForSerialization

### DIFF
--- a/src/Client/ObjectSerializer.php
+++ b/src/Client/ObjectSerializer.php
@@ -50,9 +50,9 @@ class ObjectSerializer
      * @param string|null $type   the OpenAPIToolsType of the data
      * @param string|null $format the format of the OpenAPITools type of the data
      *
-     * @return object|array|null|string serialized form of $data
+     * @return object|array|null|string|bool|int|float serialized form of $data
      */
-    public static function sanitizeForSerialization(mixed $data, string|null $type = null, string|null $format = null): object|array|null|string
+    public static function sanitizeForSerialization(mixed $data, string|null $type = null, string|null $format = null): object|array|null|string|bool|int|float
     {
         if (is_scalar($data) || null === $data) {
             return $data;

--- a/tests/Client/Api/Report/Request/SendReportDataRequestTest.php
+++ b/tests/Client/Api/Report/Request/SendReportDataRequestTest.php
@@ -25,7 +25,7 @@ class SendReportDataRequestTest extends TestCase
         $reportId = uniqid('reportId', true);
 
         $request = new SendReportDataRequest($reportId, [$sellerInventoryItem], false);
-        $this->assertSame('[{"offerId":"123","sku":"123","quantity":"1"}]', $request->getBody());
+        $this->assertSame('[{"offerId":123,"sku":"123","quantity":"1"}]', $request->getBody());
         $this->assertSame('POST', $request->getHttpMethod());
         $this->assertSame('/v1/channel/report/{reportId}/data', $request->getUrl());
         $this->assertSame(['reportId' => $reportId], $request->getParams());

--- a/tests/Client/Api/Report/Request/SendReportRequestTest.php
+++ b/tests/Client/Api/Report/Request/SendReportRequestTest.php
@@ -31,7 +31,7 @@ class SendReportRequestTest extends TestCase
         $reportId = uniqid('reportId', true);
 
         $request = new SendReportRequest($reportId, [$sellerInventoryItem], false);
-        $this->assertSame('[{"offerId":"123","sku":"123","quantity":"1"}]', $request->getBody());
+        $this->assertSame('[{"offerId":123,"sku":"123","quantity":"1"}]', $request->getBody());
         $this->assertSame('POST', $request->getHttpMethod());
         $this->assertSame('/v1/channel/report/{reportId}', $request->getUrl());
         $this->assertSame(['reportId' => $reportId], $request->getParams());
@@ -47,7 +47,7 @@ class SendReportRequestTest extends TestCase
         ]);
         $sut = new SendReportRequest($reportId, [$item], false);
 
-        $this->assertSame('[{"offerId":"123","sku":"123","quantity":"1"}]', $sut->getBody());
+        $this->assertSame('[{"offerId":123,"sku":"123","quantity":"1"}]', $sut->getBody());
         $this->assertSame('POST', $sut->getHttpMethod());
         $this->assertSame('/v1/channel/report/{reportId}', $sut->getUrl());
         $this->assertSame(['reportId' => $reportId], $sut->getParams());

--- a/tests/Client/ObjectSerializerTest.php
+++ b/tests/Client/ObjectSerializerTest.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JTL\SCX\Lib\Channel\Client;
+
+use JTL\SCX\Lib\Channel\Client\Model\Attribute;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Class ObjectSerializerTest
+ * @package JTL\SCX\Lib\Channel\Client
+ *
+ * @covers \JTL\SCX\Lib\Channel\Client\ObjectSerializer
+ */
+class ObjectSerializerTest extends TestCase
+{
+    /**
+     * Regression test: sanitizeForSerialization()'s return type union used to be
+     * `object|array|null|string`, missing bool/int/float. Without strict_types, PHP
+     * weak-coerces a returned scalar into whatever the union does allow, silently
+     * turning `false` into `""` and `0` into `"0"` on the way out to json_encode().
+     */
+    public function testSanitizeForSerializationPreservesScalarTypes(): void
+    {
+        $this->assertSame(false, ObjectSerializer::sanitizeForSerialization(false));
+        $this->assertSame(true, ObjectSerializer::sanitizeForSerialization(true));
+        $this->assertSame(0, ObjectSerializer::sanitizeForSerialization(0));
+        $this->assertSame(1.5, ObjectSerializer::sanitizeForSerialization(1.5));
+        $this->assertSame('x', ObjectSerializer::sanitizeForSerialization('x'));
+        $this->assertNull(ObjectSerializer::sanitizeForSerialization(null));
+    }
+
+    public function testModelJsonEncodesBoolAndIntPropertiesAsRealJsonTypes(): void
+    {
+        $attribute = new Attribute([
+            'attributeId' => 'x',
+            'displayName' => 'y',
+            'isMultipleAllowed' => false,
+            'required' => false,
+            'recommended' => false,
+            'sectionPosition' => 0,
+        ]);
+
+        $decoded = json_decode(json_encode($attribute), true);
+
+        $this->assertFalse($decoded['isMultipleAllowed']);
+        $this->assertFalse($decoded['required']);
+        $this->assertFalse($decoded['recommended']);
+        $this->assertSame(0, $decoded['sectionPosition']);
+    }
+}


### PR DESCRIPTION
sanitizeForSerialization()'s return type is missing bool/int/float, so PHP weak-coerces those scalars to strings on the way to json_encode() — false becomes "", 0 becomes "0". Present in every 3.x tag.

Widens the return type to include the missing scalars.

Side quest: two report-request tests had the stringified-int bug baked in as "expected" output — fixed those too.

Context: EA-8196. Template fix: https://github.com/jtl-software/jtl-marketplaces-scx-spec/pull/48. Blocks: https://github.com/jtl-software/jtl-marketplaces-amazon/pull/91.